### PR TITLE
Replace EntityManager references by Spring Data JPA CrudRepository Calls

### DIFF
--- a/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/tutor/answer/AnswerService.java
+++ b/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/tutor/answer/AnswerService.java
@@ -25,8 +25,6 @@ import pt.ulisboa.tecnico.socialsoftware.tutor.statement.dto.StatementAnswerDto;
 import pt.ulisboa.tecnico.socialsoftware.tutor.user.User;
 import pt.ulisboa.tecnico.socialsoftware.tutor.user.UserRepository;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
@@ -59,10 +57,6 @@ public class AnswerService {
     @Autowired
     private AnswersXmlImport xmlImporter;
 
-    @PersistenceContext
-    EntityManager entityManager;
-
-
     @Retryable(
       value = { SQLException.class },
       backoff = @Backoff(delay = 5000))
@@ -73,7 +67,7 @@ public class AnswerService {
         Quiz quiz = quizRepository.findById(quizId).orElseThrow(() -> new TutorException(QUIZ_NOT_FOUND, quizId));
 
         QuizAnswer quizAnswer = new QuizAnswer(user, quiz);
-        entityManager.persist(quizAnswer);
+        quizAnswerRepository.save(quizAnswer);
 
         return new QuizAnswerDto(quizAnswer);
     }

--- a/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/tutor/question/AssessmentService.java
+++ b/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/tutor/question/AssessmentService.java
@@ -20,9 +20,6 @@ import pt.ulisboa.tecnico.socialsoftware.tutor.question.dto.TopicConjunctionDto;
 import pt.ulisboa.tecnico.socialsoftware.tutor.question.repository.AssessmentRepository;
 import pt.ulisboa.tecnico.socialsoftware.tutor.question.repository.TopicConjunctionRepository;
 import pt.ulisboa.tecnico.socialsoftware.tutor.question.repository.TopicRepository;
-
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import java.sql.SQLException;
 import java.util.Comparator;
 import java.util.List;
@@ -47,9 +44,6 @@ public class AssessmentService {
 
     @Autowired
     private CourseExecutionRepository courseExecutionRepository;
-
-    @PersistenceContext
-    EntityManager entityManager;
 
     @Transactional(isolation = Isolation.REPEATABLE_READ)
     public CourseDto findAssessmentCourseExecution(int assessmentId) {
@@ -98,8 +92,8 @@ public class AssessmentService {
                 }).collect(Collectors.toList());
 
         Assessment assessment = new Assessment(courseExecution, topicConjunctions, assessmentDto);
+        assessmentRepository.save(assessment);
 
-        this.entityManager.persist(assessment);
         return new AssessmentDto(assessment);
     }
 
@@ -151,7 +145,7 @@ public class AssessmentService {
     public void removeAssessment(Integer assessmentId) {
         Assessment assessment = assessmentRepository.findById(assessmentId).orElseThrow(() -> new TutorException(ASSESSMENT_NOT_FOUND, assessmentId));
         assessment.remove();
-        entityManager.remove(assessment);
+        assessmentRepository.delete(assessment);
     }
 
     @Retryable(

--- a/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/tutor/question/QuestionService.java
+++ b/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/tutor/question/QuestionService.java
@@ -16,11 +16,10 @@ import pt.ulisboa.tecnico.socialsoftware.tutor.question.domain.Image;
 import pt.ulisboa.tecnico.socialsoftware.tutor.question.domain.Question;
 import pt.ulisboa.tecnico.socialsoftware.tutor.question.dto.QuestionDto;
 import pt.ulisboa.tecnico.socialsoftware.tutor.question.dto.TopicDto;
+import pt.ulisboa.tecnico.socialsoftware.tutor.question.repository.ImageRepository;
 import pt.ulisboa.tecnico.socialsoftware.tutor.question.repository.QuestionRepository;
 import pt.ulisboa.tecnico.socialsoftware.tutor.question.repository.TopicRepository;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.util.Arrays;
@@ -41,8 +40,8 @@ public class QuestionService {
     @Autowired
     private TopicRepository topicRepository;
 
-    @PersistenceContext
-    EntityManager entityManager;
+    @Autowired
+    private ImageRepository imageRepository;
 
     @Retryable(
       value = { SQLException.class },
@@ -101,7 +100,7 @@ public class QuestionService {
 
         Question question = new Question(course, questionDto);
         question.setCreationDate(LocalDateTime.now());
-        this.entityManager.persist(question);
+        questionRepository.save(question);
         return new QuestionDto(question);
     }
 
@@ -124,7 +123,7 @@ public class QuestionService {
     public void removeQuestion(Integer questionId) {
         Question question = questionRepository.findById(questionId).orElseThrow(() -> new TutorException(QUESTION_NOT_FOUND, questionId));
         question.remove();
-        entityManager.remove(question);
+        questionRepository.delete(question);
     }
 
     @Retryable(
@@ -151,7 +150,7 @@ public class QuestionService {
 
             question.setImage(image);
 
-            entityManager.persist(image);
+            imageRepository.save(image);
         }
 
         question.getImage().setUrl(question.getKey() + "." + type);

--- a/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/tutor/question/TopicService.java
+++ b/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/tutor/question/TopicService.java
@@ -16,8 +16,6 @@ import pt.ulisboa.tecnico.socialsoftware.tutor.question.domain.Topic;
 import pt.ulisboa.tecnico.socialsoftware.tutor.question.dto.TopicDto;
 import pt.ulisboa.tecnico.socialsoftware.tutor.question.repository.TopicRepository;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import java.sql.SQLException;
 import java.util.Comparator;
 import java.util.List;
@@ -35,9 +33,6 @@ public class TopicService {
 
     @Autowired
     private TopicRepository topicRepository;
-
-    @PersistenceContext
-    EntityManager entityManager;
 
     @Transactional(isolation = Isolation.REPEATABLE_READ)
     public CourseDto findTopicCourse(int topicId) {
@@ -70,7 +65,7 @@ public class TopicService {
         }
 
         Topic topic = new Topic(course, topicDto);
-        this.entityManager.persist(topic);
+        topicRepository.save(topic);
         return new TopicDto(topic);
     }
 
@@ -96,7 +91,7 @@ public class TopicService {
                 .orElseThrow(() -> new TutorException(TOPIC_NOT_FOUND, topicId));
 
         topic.remove();
-        entityManager.remove(topic);
+        topicRepository.delete(topic);
     }
 
 

--- a/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/tutor/quiz/QuizService.java
+++ b/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/tutor/quiz/QuizService.java
@@ -25,8 +25,6 @@ import pt.ulisboa.tecnico.socialsoftware.tutor.quiz.dto.QuizQuestionDto;
 import pt.ulisboa.tecnico.socialsoftware.tutor.quiz.repository.QuizQuestionRepository;
 import pt.ulisboa.tecnico.socialsoftware.tutor.quiz.repository.QuizRepository;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
@@ -52,9 +50,6 @@ public class QuizService {
 
     @Autowired
     private QuizQuestionRepository quizQuestionRepository;
-
-    @PersistenceContext
-    EntityManager entityManager;
 
     @Transactional(isolation = Isolation.REPEATABLE_READ)
     public CourseDto findQuizCourseExecution(int quizId) {
@@ -121,7 +116,7 @@ public class QuizService {
             DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm");
             quiz.setCreationDate(LocalDateTime.parse(quizDto.getCreationDate(), formatter));
         }
-        entityManager.persist(quiz);
+        quizRepository.save(quiz);
 
         return new QuizDto(quiz, true);
     }
@@ -145,14 +140,14 @@ public class QuizService {
         Set<QuizQuestion> quizQuestions = new HashSet<>(quiz.getQuizQuestions());
 
         quizQuestions.forEach(QuizQuestion::remove);
-        quizQuestions.forEach(quizQuestion -> entityManager.remove(quizQuestion));
+        quizQuestions.forEach(quizQuestion -> quizQuestionRepository.delete(quizQuestion));
 
         if (quizDto.getQuestions() != null) {
             for (QuestionDto questionDto : quizDto.getQuestions()) {
                 Question question = questionRepository.findById(questionDto.getId())
                         .orElseThrow(() -> new TutorException(QUESTION_NOT_FOUND, questionDto.getId()));
                 QuizQuestion quizQuestion = new QuizQuestion(quiz, question, quiz.getQuizQuestions().size());
-                entityManager.persist(quizQuestion);
+                quizQuestionRepository.save(quizQuestion);
             }
         }
 
@@ -170,7 +165,7 @@ public class QuizService {
 
         QuizQuestion quizQuestion = new QuizQuestion(quiz, question, quiz.getQuizQuestions().size());
 
-        entityManager.persist(quizQuestion);
+        quizQuestionRepository.save(quizQuestion);
 
         return new QuizQuestionDto(quizQuestion);
     }
@@ -188,9 +183,9 @@ public class QuizService {
         Set<QuizQuestion> quizQuestions = new HashSet<>(quiz.getQuizQuestions());
 
         quizQuestions.forEach(QuizQuestion::remove);
-        quizQuestions.forEach(quizQuestion -> entityManager.remove(quizQuestion));
+        quizQuestions.forEach(quizQuestion -> quizQuestionRepository.delete(quizQuestion));
 
-        entityManager.remove(quiz);
+        quizRepository.delete(quiz);
     }
 
     @Retryable(

--- a/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/tutor/statement/StatementService.java
+++ b/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/tutor/statement/StatementService.java
@@ -27,8 +27,6 @@ import pt.ulisboa.tecnico.socialsoftware.tutor.statement.dto.StatementQuizDto;
 import pt.ulisboa.tecnico.socialsoftware.tutor.user.User;
 import pt.ulisboa.tecnico.socialsoftware.tutor.user.UserRepository;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import java.sql.SQLException;
 import java.time.LocalDateTime;
 import java.time.temporal.ChronoUnit;
@@ -66,9 +64,6 @@ public class StatementService {
     @Autowired
     private AnswerService answerService;
 
-    @PersistenceContext
-    EntityManager entityManager;
-
     @Retryable(
       value = { SQLException.class },
       backoff = @Backoff(delay = 5000))
@@ -100,8 +95,8 @@ public class StatementService {
         quiz.setCourseExecution(courseExecution);
         courseExecution.addQuiz(quiz);
 
-        entityManager.persist(quiz);
-        entityManager.persist(quizAnswer);
+        quizRepository.save(quiz);
+        quizAnswerRepository.save(quizAnswer);
 
         return new StatementQuizDto(quizAnswer);
     }
@@ -124,7 +119,7 @@ public class StatementService {
 
         QuizAnswer quizAnswer = quizAnswerRepository.findQuizAnswer(quiz.getId(), user.getId()).orElseGet(() -> {
             QuizAnswer qa = new QuizAnswer(user, quiz);
-            entityManager.persist(qa);
+            quizAnswerRepository.save(qa);
             return qa;
         });
 
@@ -166,7 +161,7 @@ public class StatementService {
                 .forEach(quiz ->  {
                     if (quiz.getConclusionDate() == null || quiz.getConclusionDate().isAfter(now)) {
                         QuizAnswer quizAnswer = new QuizAnswer(user, quiz);
-                        entityManager.persist(quizAnswer);
+                        quizAnswerRepository.save(quizAnswer);
                     }
                 });
 

--- a/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/tutor/user/UserService.java
+++ b/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/tutor/user/UserService.java
@@ -13,8 +13,6 @@ import pt.ulisboa.tecnico.socialsoftware.tutor.exceptions.TutorException;
 import pt.ulisboa.tecnico.socialsoftware.tutor.impexp.domain.UsersXmlExport;
 import pt.ulisboa.tecnico.socialsoftware.tutor.impexp.domain.UsersXmlImport;
 
-import javax.persistence.EntityManager;
-import javax.persistence.PersistenceContext;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -29,9 +27,6 @@ public class UserService {
 
     @Autowired
     private CourseExecutionRepository courseExecutionRepository;
-
-    @PersistenceContext
-    EntityManager entityManager;
 
     public User findByUsername(String username) {
         return this.userRepository.findByUsername(username);
@@ -53,7 +48,7 @@ public class UserService {
         }
 
         User user = new User(name, username, getMaxUserNumber() + 1, role);
-        entityManager.persist(user);
+        userRepository.save(user);
         return user;
     }
 


### PR DESCRIPTION
There is no point in updating the database via EntityManager when we have methods that do that on the Spring Data JPA Repositories classes

Added an ImageRepository attribute on QuestionService.java class, please check if it does not require further modifications.