### PR TITLE
Multiple choice question options are not removed from the database

### DIFF
--- a/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/tutor/question/domain/MultipleChoiceQuestion.java
+++ b/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/tutor/question/domain/MultipleChoiceQuestion.java
@@ -11,6 +11,8 @@ import pt.ulisboa.tecnico.socialsoftware.tutor.question.dto.QuestionDetailsDto;
 import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 import static pt.ulisboa.tecnico.socialsoftware.tutor.exceptions.ErrorMessage.*;
@@ -18,10 +20,8 @@ import static pt.ulisboa.tecnico.socialsoftware.tutor.exceptions.ErrorMessage.*;
 @Entity
 @DiscriminatorValue(Question.QuestionTypes.MULTIPLE_CHOICE_QUESTION)
 public class MultipleChoiceQuestion extends QuestionDetails {
-
     @OneToMany(cascade = CascadeType.ALL, mappedBy = "questionDetails", fetch = FetchType.EAGER, orphanRemoval = true)
     private final List<Option> options = new ArrayList<>();
-
 
     public MultipleChoiceQuestion() {
         super();
@@ -36,26 +36,20 @@ public class MultipleChoiceQuestion extends QuestionDetails {
         return options;
     }
 
-    public void setOptions(List<OptionDto> options) {
-        if (options.stream().filter(OptionDto::isCorrect).count() != 1) {
+    public void setOptions(List<OptionDto> optionDtos) {
+        if (optionDtos.stream().filter(OptionDto::isCorrect).count() != 1) {
             throw new TutorException(ONE_CORRECT_OPTION_NEEDED);
         }
 
-        int index = 0;
-        for (OptionDto optionDto : options) {
-            if (optionDto.getId() == null) {
-                optionDto.setSequence(index++);
-                new Option(optionDto).setQuestionDetails(this);
-            } else {
-                Option option = getOptions()
-                        .stream()
-                        .filter(op -> op.getId().equals(optionDto.getId()))
-                        .findAny()
-                        .orElseThrow(() -> new TutorException(OPTION_NOT_FOUND, optionDto.getId()));
+        for (Option option: this.options) {
+            option.remove();
+        }
+        this.options.clear();
 
-                option.setContent(optionDto.getContent());
-                option.setCorrect(optionDto.isCorrect());
-            }
+        int index = 0;
+        for (OptionDto optionDto : optionDtos) {
+            optionDto.setSequence(index++);
+            new Option(optionDto).setQuestionDetails(this);
         }
     }
 

--- a/backend/src/test/groovy/pt/ulisboa/tecnico/socialsoftware/tutor/question/service/UpdateQuestionTest.groovy
+++ b/backend/src/test/groovy/pt/ulisboa/tecnico/socialsoftware/tutor/question/service/UpdateQuestionTest.groovy
@@ -65,7 +65,7 @@ class UpdateQuestionTest extends SpockTest {
         optionRepository.save(optionOK)
 
         optionKO = new Option()
-        optionKO.setContent(OPTION_1_CONTENT)
+        optionKO.setContent(OPTION_2_CONTENT)
         optionKO.setCorrect(false)
         optionKO.setSequence(1)
         optionKO.setQuestionDetails(questionDetails)
@@ -81,13 +81,14 @@ class UpdateQuestionTest extends SpockTest {
         and: '2 changed options'
         def options = new ArrayList<OptionDto>()
         def optionDto = new OptionDto(optionOK)
-        optionDto.setContent(OPTION_2_CONTENT)
         optionDto.setCorrect(false)
         options.add(optionDto)
         optionDto = new OptionDto(optionKO)
         optionDto.setCorrect(true)
         options.add(optionDto)
         questionDto.getQuestionDetailsDto().setOptions(options)
+        and: 'a count to load options to memory due to in memory database flaw'
+        optionRepository.count();
 
         when:
         questionService.updateQuestion(question.getId(), questionDto)
@@ -106,12 +107,12 @@ class UpdateQuestionTest extends SpockTest {
         result.getImage() != null
         and: 'an option is changed'
         result.getQuestionDetails().getOptions().size() == 2
-        def resOptionOne = result.getQuestionDetails().getOptions().stream().filter({ option -> option.getId() == optionOK.getId()}).findAny().orElse(null)
+        def resOptionOne = result.getQuestionDetails().getOptions().stream().filter({ option -> option.isCorrect()}).findAny().orElse(null)
         resOptionOne.getContent() == OPTION_2_CONTENT
-        !resOptionOne.isCorrect()
-        def resOptionTwo = result.getQuestionDetails().getOptions().stream().filter({ option -> option.getId() == optionKO.getId()}).findAny().orElse(null)
+        def resOptionTwo = result.getQuestionDetails().getOptions().stream().filter({ option -> !option.isCorrect()}).findAny().orElse(null)
         resOptionTwo.getContent() == OPTION_1_CONTENT
-        resOptionTwo.isCorrect()
+        and: 'there are two questions in the database'
+        optionRepository.findAll().size() == 2
     }
 
     def "update question with missing data"() {
@@ -138,7 +139,7 @@ class UpdateQuestionTest extends SpockTest {
         def options = new ArrayList<OptionDto>()
         options.add(optionDto)
         optionDto = new OptionDto(optionKO)
-        optionDto.setContent(OPTION_1_CONTENT)
+        optionDto.setContent(OPTION_2_CONTENT)
         optionDto.setCorrect(true)
         options.add(optionDto)
         questionDto.getQuestionDetailsDto().setOptions(options)
@@ -216,42 +217,39 @@ class UpdateQuestionTest extends SpockTest {
         exception.getErrorMessage() == ErrorMessage.CANNOT_CHANGE_ANSWERED_QUESTION
     }
 
-
-    def "new test update MultipleChoiceQuestion remove old options add new ones"() {
+    def "update MultipleChoiceQuestion remove old option add new one"() {
         given: "a changed question"
         def questionDto = new QuestionDto(question)
         def multipleChoiceQuestionDto = new MultipleChoiceQuestionDto()
         questionDto.setQuestionDetailsDto(multipleChoiceQuestionDto)
-
-        and: 'the new options'
-        def newOptionOK = new OptionDto()
-        newOptionOK.setContent(OPTION_2_CONTENT)
-        newOptionOK.setCorrect(true)
-        newOptionOK.setSequence(0)
-
+        and: 'a the old correct option'
+        def newOptionOK = new OptionDto(optionOK)
+        and: 'a new option'
         def newOptionKO = new OptionDto()
-        newOptionKO.setContent(OPTION_2_CONTENT)
+        newOptionKO.setContent(OPTION_1_CONTENT)
         newOptionKO.setCorrect(false)
-        newOptionKO.setSequence(1)
-
+        and: 'add options to dto'
         def newOptions = new ArrayList<OptionDto>()
         newOptions.add(newOptionOK)
         newOptions.add(newOptionKO)
         multipleChoiceQuestionDto.setOptions(newOptions)
+        and: 'a count to load options to memory due to in memory database flaw'
+        optionRepository.count();
 
         when:
         questionService.updateQuestion(question.getId(), questionDto)
 
-        then:'optionRepository only has two options'
-        optionRepository.findAll().size() == 2
-
-        and:'the question only has the two new options'
+        then: "the question is there"
+        questionRepository.count() == 1L
         def result = questionRepository.findAll().get(0)
+        and: 'an option is changed'
         result.getQuestionDetails().getOptions().size() == 2
-        def resOptionOne = result.getQuestionDetails().getOptions().get(0)
-        resOptionOne.getContent() == OPTION_2_CONTENT
-        def resOptionTwo = result.getQuestionDetails().getOptions().get(1)
-        resOptionTwo.getContent() == OPTION_2_CONTENT
+        def resOptionOne = result.getQuestionDetails().getOptions().stream().filter({ option -> option.isCorrect()}).findAny().orElse(null)
+        resOptionOne.getContent() == OPTION_1_CONTENT
+        def resOptionTwo = result.getQuestionDetails().getOptions().stream().filter({ option -> !option.isCorrect()}).findAny().orElse(null)
+        resOptionTwo.getContent() == OPTION_1_CONTENT
+        and: 'there are two questions in the database'
+        optionRepository.findAll().size() == 2
     }
 
     @TestConfiguration

--- a/backend/src/test/groovy/pt/ulisboa/tecnico/socialsoftware/tutor/question/service/UpdateQuestionTest.groovy
+++ b/backend/src/test/groovy/pt/ulisboa/tecnico/socialsoftware/tutor/question/service/UpdateQuestionTest.groovy
@@ -216,6 +216,44 @@ class UpdateQuestionTest extends SpockTest {
         exception.getErrorMessage() == ErrorMessage.CANNOT_CHANGE_ANSWERED_QUESTION
     }
 
+
+    def "new test update MultipleChoiceQuestion remove old options add new ones"() {
+        given: "a changed question"
+        def questionDto = new QuestionDto(question)
+        def multipleChoiceQuestionDto = new MultipleChoiceQuestionDto()
+        questionDto.setQuestionDetailsDto(multipleChoiceQuestionDto)
+
+        and: 'the new options'
+        def newOptionOK = new OptionDto()
+        newOptionOK.setContent(OPTION_2_CONTENT)
+        newOptionOK.setCorrect(true)
+        newOptionOK.setSequence(0)
+
+        def newOptionKO = new OptionDto()
+        newOptionKO.setContent(OPTION_2_CONTENT)
+        newOptionKO.setCorrect(false)
+        newOptionKO.setSequence(1)
+
+        def newOptions = new ArrayList<OptionDto>()
+        newOptions.add(newOptionOK)
+        newOptions.add(newOptionKO)
+        multipleChoiceQuestionDto.setOptions(newOptions)
+
+        when:
+        questionService.updateQuestion(question.getId(), questionDto)
+
+        then:'optionRepository only has two options'
+        optionRepository.findAll().size() == 2
+
+        and:'the question only has the two new options'
+        def result = questionRepository.findAll().get(0)
+        result.getQuestionDetails().getOptions().size() == 2
+        def resOptionOne = result.getQuestionDetails().getOptions().get(0)
+        resOptionOne.getContent() == OPTION_2_CONTENT
+        def resOptionTwo = result.getQuestionDetails().getOptions().get(1)
+        resOptionTwo.getContent() == OPTION_2_CONTENT
+    }
+
     @TestConfiguration
     static class LocalBeanConfiguration extends BeanConfiguration {}
 }

--- a/backend/src/test/groovy/pt/ulisboa/tecnico/socialsoftware/tutor/questionsubmission/service/UpdateQuestionSubmissionTest.groovy
+++ b/backend/src/test/groovy/pt/ulisboa/tecnico/socialsoftware/tutor/questionsubmission/service/UpdateQuestionSubmissionTest.groovy
@@ -68,7 +68,9 @@ class UpdateQuestionSubmissionTest extends SpockTest {
         and: "a questionSubmissionDto"
         def questionSubmissionDto = new QuestionSubmissionDto(questionSubmission)
         questionSubmissionDto.setQuestion(questionDto)
-
+        and: 'a count to load options to memory due to in memory database flaw'
+        optionRepository.count();
+        
         when:
         questionSubmissionService.updateQuestionSubmission(questionSubmission.getId(), questionSubmissionDto)
 


### PR DESCRIPTION
Added a new test case to check that options are removed when a question is updated and they aren't used.