### PR TITLE
[XmlImport] fix exception message to use the right string format

### DIFF
--- a/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/tutor/exceptions/ErrorMessage.java
+++ b/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/tutor/exceptions/ErrorMessage.java
@@ -33,6 +33,7 @@ public enum ErrorMessage {
 
     ASSESSMENT_NOT_FOUND("Assessment not found with id %d"),
     COURSE_EXECUTION_NOT_FOUND("Course execution not found with id %d"),
+    COURSE_EXECUTION_NOT_FOUND_STR("Course execution not found with id %s"),
     COURSE_EXECUTION_NOT_EXTERNAL("The course execution with id %d is not external"),
     INVALID_EMAIL("The mail %s is invalid."),
     INVALID_PASSWORD("The password %s is invalid."),

--- a/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/tutor/impexp/domain/AnswersXmlImport.java
+++ b/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/tutor/impexp/domain/AnswersXmlImport.java
@@ -155,7 +155,7 @@ public class AnswersXmlImport {
         Course course = courseRepository.findByNameType(courseName, courseType)
                 .orElseThrow(() -> new TutorException(COURSE_NOT_FOUND, courseName + ":" + courseType));
         CourseExecution courseExecution = course.getCourseExecution(acronym, academicTerm, Course.Type.valueOf(courseExecutionType))
-                .orElseThrow(() -> new TutorException(COURSE_EXECUTION_NOT_FOUND, acronym));
+                .orElseThrow(() -> new TutorException(COURSE_EXECUTION_NOT_FOUND_STR, acronym));
 
         Integer quizKey = Integer.valueOf(quizElement.getAttributeValue("key"));
         Quiz quiz = courseExecution.getQuizzes().stream()

--- a/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/tutor/impexp/domain/QuizzesXmlImport.java
+++ b/backend/src/main/java/pt/ulisboa/tecnico/socialsoftware/tutor/impexp/domain/QuizzesXmlImport.java
@@ -151,7 +151,7 @@ public class QuizzesXmlImport {
                 .orElseThrow(() -> new TutorException(COURSE_NOT_FOUND, courseName + ":" + courseType));
 
         CourseExecution courseExecution = course.getCourseExecution(acronym, academicTerm, Course.Type.valueOf(courseExecutionType))
-                .orElseThrow(() -> new TutorException(COURSE_EXECUTION_NOT_FOUND, acronym));
+                .orElseThrow(() -> new TutorException(COURSE_EXECUTION_NOT_FOUND_STR, acronym));
 
         QuizDto quizDto2 = quizService.createQuiz(courseExecution.getId(), quizDto);
         importQuizQuestions(quizElement.getChild("quizQuestions"), quizDto2);


### PR DESCRIPTION
It was previously failing on my computer with:
```
java.util.IllegalFormatConversionException: d != java.lang.String
	at java.base/java.util.Formatter$FormatSpecifier.failConversion(Formatter.java:4426)
	at java.base/java.util.Formatter$FormatSpecifier.printInteger(Formatter.java:2938)
	at java.base/java.util.Formatter$FormatSpecifier.print(Formatter.java:2892)
	at java.base/java.util.Formatter.format(Formatter.java:2673)
	at java.base/java.util.Formatter.format(Formatter.java:2609)
	at java.base/java.lang.String.format(String.java:2897)
	at pt.ulisboa.tecnico.socialsoftware.tutor.exceptions.TutorException.<init>(TutorException.java:20)
	at pt.ulisboa.tecnico.socialsoftware.tutor.impexp.domain.AnswersXmlImport.lambda$importQuizAnswer$7(AnswersXmlImport.java:158)
	at java.base/java.util.Optional.orElseThrow(Optional.java:408)
	at pt.ulisboa.tecnico.socialsoftware.tutor.impexp.domain.AnswersXmlImport.importQuizAnswer(AnswersXmlImport.java:158)
	at pt.ulisboa.tecnico.socialsoftware.tutor.impexp.domain.AnswersXmlImport.importQuizAnswers(AnswersXmlImport.java:128)
	at pt.ulisboa.tecnico.socialsoftware.tutor.impexp.domain.AnswersXmlImport.importAnswers(AnswersXmlImport.java:99)
	at pt.ulisboa.tecnico.socialsoftware.tutor.impexp.domain.AnswersXmlImport.importAnswers(AnswersXmlImport.java:121)
	at pt.ulisboa.tecnico.socialsoftware.tutor.answer.AnswerService.importAnswers(AnswerService.java:260)
```